### PR TITLE
Streamline types and type conversions to align type systems better

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -385,6 +385,14 @@ export class EthereumValue {
     return EthereumValue.fromArray(out)
   }
 
+  static fromFixedBytesArray(values: Array<Bytes>): EthereumValue {
+    let out = new Array<EthereumValue>(values.length)
+    for (let i: i32 = 0; i < values.length; i++) {
+      out[i] = EthereumValue.fromFixedBytes(values[i])
+    }
+    return EthereumValue.fromArray(out)
+  }
+
   static fromAddressArray(values: Array<Address>): EthereumValue {
     let out = new Array<EthereumValue>(values.length)
     for (let i: i32 = 0; i < values.length; i++) {

--- a/index.ts
+++ b/index.ts
@@ -37,10 +37,10 @@ export declare namespace json {
 
 /** Host type conversion interface */
 declare namespace typeConversion {
-  function bytesToString(bytes: ByteArray): string
+  function bytesToString(bytes: Uint8Array): string
   function bytesToHex(bytes: Uint8Array): string
-  function u64ArrayToHex(array: Uint64Array): string
-  function u64ArrayToString(array: Uint64Array): string
+  function bigIntToString(bigInt: Uint8Array): string
+  function bigIntToHex(bigInt: Uint8Array): string
   function stringToH160(s: String): Bytes
 
   //// Primitive to/from ethereum 256-bit number conversions.
@@ -111,17 +111,6 @@ export class ByteArray extends Uint8Array {
   }
 }
 
-/** U64Array */
-export class U64Array extends Uint64Array {
-  toHex(): string {
-    return typeConversion.u64ArrayToHex(this)
-  }
-
-  toString(): string {
-    return typeConversion.u64ArrayToString(this)
-  }
-}
-
 /** A dynamically-sized byte array. */
 export class Bytes extends ByteArray {
   constructor() {}
@@ -136,9 +125,17 @@ export class Address extends Bytes {
   }
 }
 
-/** An arbitrary size integer represented as an array of 64 bit values. */
+/** An arbitrary size integer represented as an array of bytes. */
 export class BigInt extends Uint8Array {
   constructor() {}
+
+  toHex(): string {
+    return typeConversion.bigIntToHex(this)
+  }
+
+  toString(): string {
+    return typeConversion.bigIntToString(this)
+  }
 
   static fromI32(x: i32): BigInt {
     return typeConversion.i32ToBigInt(x) as BigInt

--- a/index.ts
+++ b/index.ts
@@ -44,9 +44,8 @@ declare namespace typeConversion {
   function stringToH160(s: String): Bytes
 
   //// Primitive to/from ethereum 256-bit number conversions.
-  function i32ToBigInt(x: i32): Uint64Array
-  function u32ToBigInt(x: i32): Uint64Array
-  function bigIntToI32(x: Uint64Array): i32
+  function i32ToBigInt(x: i32): Uint8Array
+  function bigIntToI32(x: Uint8Array): i32
 }
 
 /**
@@ -138,15 +137,11 @@ export class Address extends Bytes {
 }
 
 /** An arbitrary size integer represented as an array of 64 bit values. */
-export class BigInt extends U64Array {
+export class BigInt extends Uint8Array {
   constructor() {}
 
   static fromI32(x: i32): BigInt {
     return typeConversion.i32ToBigInt(x) as BigInt
-  }
-
-  static fromU32(x: u32): BigInt {
-    return typeConversion.u32ToBigInt(x) as BigInt
   }
 
   toI32(): i32 {

--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,6 @@ declare namespace typeConversion {
   //// Primitive to/from ethereum 256-bit number conversions.
   function i32ToBigInt(x: i32): Uint64Array
   function u32ToBigInt(x: i32): Uint64Array
-  function bigIntToU32(x: Uint64Array): u32
   function bigIntToI32(x: Uint64Array): i32
 }
 
@@ -153,10 +152,6 @@ export class BigInt extends U64Array {
   toI32(): i32 {
     return typeConversion.bigIntToI32(this)
   }
-
-  toU32(): u32 {
-    return typeConversion.bigIntToU32(this)
-  }
 }
 
 /** Type hint for Ethereum values. */
@@ -208,12 +203,6 @@ export class EthereumValue {
     assert(this.kind == EthereumValueKind.INT, 'EthereumValue is not an int.')
     let bigInt = changetype<BigInt>(this.data as u32)
     return bigInt.toI32()
-  }
-
-  toU32(): u32 {
-    assert(this.kind == EthereumValueKind.UINT, 'EthereumValue is not a uint.')
-    let bigInt = changetype<BigInt>(this.data as u32)
-    return bigInt.toU32()
   }
 
   toBigInt(): BigInt {
@@ -302,19 +291,6 @@ export class EthereumValue {
     return out
   }
 
-  toU32Array(): Array<u32> {
-    assert(
-      this.kind == EthereumValueKind.ARRAY || this.kind == EthereumValueKind.FIXED_ARRAY,
-      'EthereumValue is not an array or fixed array.'
-    )
-    let valueArray = this.toArray()
-    let out = new Array<u32>(valueArray.length)
-    for (let i: i32 = 0; i < valueArray.length; i++) {
-      out[i] = valueArray[i].toU32()
-    }
-    return out
-  }
-
   toBigIntArray(): Array<BigInt> {
     assert(
       this.kind == EthereumValueKind.ARRAY || this.kind == EthereumValueKind.FIXED_ARRAY,
@@ -362,13 +338,6 @@ export class EthereumValue {
     let token = new EthereumValue()
     token.kind = EthereumValueKind.INT
     token.data = BigInt.fromI32(i) as u64
-    return token
-  }
-
-  static fromU32(u: u32): EthereumValue {
-    let token = new EthereumValue()
-    token.kind = EthereumValueKind.UINT
-    token.data = BigInt.fromU32(u) as u64
     return token
   }
 
@@ -440,14 +409,6 @@ export class EthereumValue {
     return EthereumValue.fromArray(out)
   }
 
-  static fromU32Array(values: Array<u32>): EthereumValue {
-    let out = new Array<EthereumValue>(values.length)
-    for (let i: i32 = 0; i < values.length; i++) {
-      out[i] = EthereumValue.fromU32(values[i])
-    }
-    return EthereumValue.fromArray(out)
-  }
-
   static fromSignedBigIntArray(values: Array<BigInt>): EthereumValue {
     let out = new Array<EthereumValue>(values.length)
     for (let i: i32 = 0; i < values.length; i++) {
@@ -513,11 +474,6 @@ export class Value {
     return this.data as i32
   }
 
-  toU32(): u32 {
-    assert(this.kind == ValueKind.INT, 'Value is not an u32.')
-    return this.data as u32
-  }
-
   toString(): string {
     assert(this.kind == ValueKind.STRING, 'Value is not a string.')
     return changetype<string>(this.data as u32)
@@ -565,15 +521,6 @@ export class Value {
     let output = new Array<i32>(values.length)
     for (let i: i32 = 0; i < values.length; i++) {
       output[i] = values[i].toI32()
-    }
-    return output
-  }
-
-  toU32Array(): Array<u32> {
-    let values = this.toArray()
-    let output = new Array<i32>(values.length)
-    for (let i: i32 = 0; i < values.length; i++) {
-      output[i] = values[i].toU32()
     }
     return output
   }
@@ -664,13 +611,6 @@ export class Value {
   static fromI32(n: i32): Value {
     let value = new Value()
     value.kind = ValueKind.INT
-    value.data = n as u64
-    return value
-  }
-
-  static fromU32(n: u32): Value {
-    let value = new Value()
-    value.kind = ValueKind.UINT
     value.data = n as u64
     return value
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./node_modules/assemblyscript/std/assembly/tsconfig.json",
+  "extends": "./node_modules/assemblyscript/tsconfig.assembly.json",
   "include": ["index.ts"]
 }


### PR DESCRIPTION
This PR aligns the different type systems (`EthereumValue`, `Value`, AssemblyScript types) better. 

Among other things, it reduces the integer types used in mappings to `{u,i}32` and `BigInt`, removing special hash data types in favor of just `Bytes` and removes `getFoo()` and `toFoo()` methods from the `Entity` type. The code generated by `graph-cli` will just use `get()` and convert the returned `Value` to the desired output type.

This PR introduces breaking changes by requiring the host (`graph-node`) to export different type conversions.