### PR TITLE
Revert allocate_memory export, as it breaks builds

### DIFF
--- a/global/global.ts
+++ b/global/global.ts
@@ -1,2 +1,5 @@
-import "allocator/arena";
-export { allocate_memory };
+// TODO: Figure out a way to essentially do the following, so mappings
+// don't have to do it themselves:
+//
+// import 'allocator/arena'
+// export { allocate_memory }

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,3 @@
-// Export allocator functions for hosts to manage WASM memory
-import { allocate_memory as allocate } from 'allocator/arena'
-export const allocate_memory = allocate
-
 /**
  * Host store interface.
  */


### PR DESCRIPTION
See https://github.com/graphprotocol/graph-cli/pull/160#issuecomment-435347390.