### PR TITLE
index.ts: Attempt to fix `Entity` constructor

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -662,7 +662,9 @@ export class Value {
  * `Value` objects.
  */
 export class Entity extends TypedMap<string, Value> {
-  constructor() {}
+  constructor() {
+    this.entries = new Array<TypedMapEntry<string, Value>>(0)
+  }
 
   unset(key: string): void {
     this.set(key, Value.fromNull())


### PR DESCRIPTION
These are uncessary, because calling new on a subclass will call the superclass constructor. Or at least I hope it calls the constructor, but it certainly works somehow.

These are also harmful because in the current shape they certainly don't call the super constructor.

At this point my best guess is that the empty constructor on `Entity` is causing https://github.com/graphprotocol/graph-node/issues/600.