### PR TITLE
index.ts: Add `isSet` to `TypedMap`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -104,6 +104,15 @@ export class TypedMap<K, V> {
     }
     return null
   }
+
+  isSet(key: K): bool {
+    for (let i: i32 = 0; i < this.entries.length; i++) {
+      if (this.entries[i].key == key) {
+        return true
+      }
+    }
+    return false
+  }
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -505,6 +505,9 @@ export class Value {
   }
 
   toBoolean(): boolean {
+    if (this.kind == ValueKind.NULL) {
+      return false;
+    }
     assert(this.kind == ValueKind.BOOL, 'Value is not a boolean.')
     return this.data != 0
   }
@@ -515,6 +518,9 @@ export class Value {
   }
 
   toI32(): i32 {
+    if (this.kind == ValueKind.NULL) {
+      return 0;
+    }
     assert(this.kind == ValueKind.INT, 'Value is not an i32.')
     return this.data as i32
   }


### PR DESCRIPTION
So that it's possible to differentiate an unset `bool` from `false`. See https://github.com/graphprotocol/graph-cli/pull/185. This also allows calling `toBoolean` or `toInt` on a `NULL`, to be consistent with the codegen behaviour.