### PR TITLE
Add bytes to base58 conversion

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,7 @@ declare namespace typeConversion {
   function bigIntToString(bigInt: Uint8Array): string
   function bigIntToHex(bigInt: Uint8Array): string
   function stringToH160(s: string): Bytes
+  function bytesToBase58(n: Uint8Array): string
 
   //// Primitive to/from ethereum 256-bit number conversions.
   function i32ToBigInt(x: i32): Uint8Array
@@ -125,6 +126,10 @@ export class ByteArray extends Uint8Array {
 
   toString(): string {
     return typeConversion.bytesToString(this)
+  }
+
+  toBase58(): string {
+    return typeConversion.bytesToBase58(this)
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,11 @@ fs.mkdirSync("test/temp_lib");
 fs.copyFileSync("index.ts", "test/temp_lib/index.ts");
 
 try {
-  asc.main(["test/test.ts", "--lib", "test", "--validate", "--noTreeShaking", "--noEmit"]);
+  // --noTreeShaking started causing using errors, so this only tests that
+  // things used in `test.ts` compile correctly, we should improve this.
+  if (asc.main(["test/test.ts", "--lib", "test", "--validate", "--noEmit"]) != 0) {
+    process.exitCode = 1
+  }
 } catch(e) {
   process.exitCode = 1
   throw e

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,1 +1,7 @@
-import 'temp_lib/index'
+import { ByteArray } from 'temp_lib/index'
+
+// `export` so this isn't considered dead code.
+export function foo(): void {
+    let a = new ByteArray(0)
+    let b: string = a.toBase58()
+}


### PR DESCRIPTION
Resolves #32.

Also do some necessary test chagnes, after the asc bump noTreeShaking started causing issues, causing the test to fail. First, now test failures will actually fail CI. Second, remove noTreeShaking which makes the test almost useless, but we can gradually make it useful again.

@davekaj let me know if this works for you.