### PR TITLE
Add `toHexString`, a more discoverable duplicate of `toHex()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ import { Domain } from './types/schema'
 
 function handleNameRegistered(event: NameRegistered) {
   // Example use of a crypto function
-  let id = crypto.keccak256(name).toHex()
+  let id = crypto.keccak256(name).toHexString()
 
   // Example use of the generated `Entry` class
   let domain = new Domain()
@@ -59,11 +59,9 @@ Refer to the `helper-functions.ts` file in this repository for a few common func
 
 ## API
 
-We will document the functionality provided by `graph-ts` soon. Until
-then, please check the types and modules exported from the
-[library source code](index.ts).
+Documentation on the API can be found [here](https://thegraph.com/docs/assemblyscript-api#api-reference).
 
-Also check out subgraphs that use the `graph-ts` library:
+For examples of `graph-ts` in use take a look at one of the following subgraphs:
 * https://github.com/graphprotocol/ens-subgraph
 * https://github.com/graphprotocol/decentraland-subgraph
 * https://github.com/graphprotocol/adchain-subgraph

--- a/index.ts
+++ b/index.ts
@@ -124,6 +124,10 @@ export class ByteArray extends Uint8Array {
     return typeConversion.bytesToHex(this)
   }
 
+  toHexString(): string {
+    return typeConversion.bytesToHex(this)
+  }
+
   toString(): string {
     return typeConversion.bytesToString(this)
   }
@@ -152,6 +156,10 @@ export class BigInt extends Uint8Array {
   constructor() {}
 
   toHex(): string {
+    return typeConversion.bigIntToHex(this)
+  }
+
+  toHexString(): string {
     return typeConversion.bigIntToHex(this)
   }
 


### PR DESCRIPTION
Resolve #41 

- Create a new functions `bytes.toHexString()` `bytes.toHexString()`, duplicates of toHex()`.
- Update README to recommend using `toHexString()` in example code.
- Add conversion table reference to provide guidance for parsing and data conversion with `graph-ts`.

To do once merged:
- Update [documentation](https://thegraph.com/docs/assemblyscript-api#api-reference) to include toHexString() reference and examples.
- Update subgraphs to use `toHexString()`.