### PR TITLE
Add Tuple support 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -818,10 +818,11 @@ export class Value {
 }
 
 /**
- * An array of dynamically typed Ethereum Values
+ * Common representation for Ethereum tuples / Solidity structs.
  *
- * Represents a Tuple in the ABI which corresponds to a Struct in Solidity
- *
+ * This base class stores the tuple/struct values in an array. The Graph CLI
+ * code generation then creates subclasses that provide named getters to
+ * access the members by name.
  */
 export class EthereumTuple extends Array<EthereumValue> {}
 

--- a/index.ts
+++ b/index.ts
@@ -297,6 +297,7 @@ export enum EthereumValueKind {
   STRING = 6,
   FIXED_ARRAY = 7,
   ARRAY = 8,
+  TUPLE = 9,
 }
 
 /**
@@ -359,6 +360,14 @@ export class EthereumValue {
       'EthereumValue is not an array.'
     )
     return changetype<Array<EthereumValue>>(this.data as u32)
+  }
+
+  toTuple(): Tuple {
+    assert(
+        this.kind == EthereumValueKind.TUPLE,
+        'EthereumValue is not a tuple.'
+    )
+    return changetype<Tuple>(this.data as u32)
   }
 
   toBooleanArray(): Array<boolean> {
@@ -500,6 +509,13 @@ export class EthereumValue {
   static fromArray(values: Array<EthereumValue>): EthereumValue {
     let token = new EthereumValue()
     token.kind = EthereumValueKind.ARRAY
+    token.data = values as u64
+    return token
+  }
+
+  static fromTuple(values: Tuple): EthereumValue {
+    let token = new EthereumValue()
+    token.kind = EthereumValueKind.TUPLE
     token.data = values as u64
     return token
   }
@@ -800,6 +816,8 @@ export class Value {
     return value
   }
 }
+
+export class Tuple extends Array<EthereumValue> {}
 
 /**
  * Common representation for entity data, storing entity attributes

--- a/index.ts
+++ b/index.ts
@@ -362,12 +362,12 @@ export class EthereumValue {
     return changetype<Array<EthereumValue>>(this.data as u32)
   }
 
-  toTuple(): Tuple {
+  toTuple(): EthereumTuple {
     assert(
         this.kind == EthereumValueKind.TUPLE,
         'EthereumValue is not a tuple.'
     )
-    return changetype<Tuple>(this.data as u32)
+    return changetype<EthereumTuple>(this.data as u32)
   }
 
   toBooleanArray(): Array<boolean> {
@@ -513,7 +513,7 @@ export class EthereumValue {
     return token
   }
 
-  static fromTuple(values: Tuple): EthereumValue {
+  static fromTuple(values: EthereumTuple): EthereumValue {
     let token = new EthereumValue()
     token.kind = EthereumValueKind.TUPLE
     token.data = values as u64
@@ -817,7 +817,13 @@ export class Value {
   }
 }
 
-export class Tuple extends Array<EthereumValue> {}
+/**
+ * An array of dynamically typed Ethereum Values
+ *
+ * Represents a Tuple in the ABI which corresponds to a Struct in Solidity
+ *
+ */
+export class EthereumTuple extends Array<EthereumValue> {}
 
 /**
  * Common representation for entity data, storing entity attributes


### PR DESCRIPTION
Part of the Solidity structs epic: [graph-node issue #766](https://github.com/graphprotocol/graph-node/issues/766)

Include a Tuple class that extends `Array<EthereumValue>` and it's corresponding conversion functions. 