### PR TITLE
More BigInt and Bytes methods

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -203,20 +203,20 @@ export class ByteArray extends Uint8Array {
         assert(false, "overflow converting " + this.toHexString() + " to u32")
       }
     }
-    let padded_bytes = new Bytes(4);
-    padded_bytes[0] = 0;
-    padded_bytes[1] = 0;
-    padded_bytes[2] = 0;
-    padded_bytes[3] = 0;
-    let min_len = padded_bytes.length < this.length ? padded_bytes.length : this.length;
-    for (let i = 0; i < min_len; i++) {
-      padded_bytes[i] = this[i]
+    let paddedBytes = new Bytes(4);
+    paddedBytes[0] = 0;
+    paddedBytes[1] = 0;
+    paddedBytes[2] = 0;
+    paddedBytes[3] = 0;
+    let minLen = paddedBytes.length < this.length ? paddedBytes.length : this.length;
+    for (let i = 0; i < minLen; i++) {
+      paddedBytes[i] = this[i]
     }
     let x: u32 = 0;
-    x = (x | padded_bytes[3]) << 8;
-    x = (x | padded_bytes[2]) << 8;
-    x = (x | padded_bytes[1]) << 8;
-    x = (x | padded_bytes[0]);
+    x = (x | paddedBytes[3]) << 8;
+    x = (x | paddedBytes[2]) << 8;
+    x = (x | paddedBytes[1]) << 8;
+    x = (x | paddedBytes[0]);
     return x;
   }
 
@@ -225,27 +225,27 @@ export class ByteArray extends Uint8Array {
    * Throws in case of overflow.
    */ 
   toI32(): i32 {
-    let is_neg = this.length > 0 && (this[this.length - 1] >> 7) == 1;
-    let padding = is_neg ? 255 : 0;
+    let isNeg = this.length > 0 && (this[this.length - 1] >> 7) == 1;
+    let padding = isNeg ? 255 : 0;
     for (let i = 4; i < this.length; i++) {
       if (this[i] != padding) {
         assert(false, "overflow converting " + this.toHexString() + " to u32")
       }
     }
-    let padded_bytes = new Bytes(4);
-    padded_bytes[0] = padding;
-    padded_bytes[1] = padding;
-    padded_bytes[2] = padding;
-    padded_bytes[3] = padding;
-    let min_len = padded_bytes.length < this.length ? padded_bytes.length : this.length
-    for (let i = 0; i < min_len; i++) {
-      padded_bytes[i] = this[i]
+    let paddedBytes = new Bytes(4);
+    paddedBytes[0] = padding;
+    paddedBytes[1] = padding;
+    paddedBytes[2] = padding;
+    paddedBytes[3] = padding;
+    let minLen = paddedBytes.length < this.length ? paddedBytes.length : this.length
+    for (let i = 0; i < minLen; i++) {
+      paddedBytes[i] = this[i]
     }
     let x: i32 = 0;
-    x = (x | padded_bytes[3]) << 8;
-    x = (x | padded_bytes[2]) << 8;
-    x = (x | padded_bytes[1]) << 8;
-    x = (x | padded_bytes[0]);
+    x = (x | paddedBytes[3]) << 8;
+    x = (x | paddedBytes[2]) << 8;
+    x = (x | paddedBytes[1]) << 8;
+    x = (x | paddedBytes[0]);
     return x;
   }
 }
@@ -277,12 +277,12 @@ export class BigInt extends Uint8Array {
    * `bytes` assumed to be little-endian. If your input is big-endian, call `.reverse()` first.
    */ 
   static fromUnsignedBytes(bytes: Bytes): BigInt {
-    let signed_bytes = new BigInt(bytes.length + 1);
+    let signedBytes = new BigInt(bytes.length + 1);
     for (let i = 0; i < bytes.length; i++) {
-      signed_bytes[i] = bytes[i]
+      signedBytes[i] = bytes[i]
     }
-    signed_bytes[bytes.length] = 0
-    return signed_bytes
+    signedBytes[bytes.length] = 0
+    return signedBytes
   }
 
   toHex(): string {
@@ -388,43 +388,43 @@ export class BigInt extends Uint8Array {
    */
   static compare(a: BigInt, b: BigInt): i32 {
     // Check if a and b have the same sign.
-    let a_is_neg = a.length > 0 && (a[a.length - 1] >> 7) == 1
-    let b_is_neg = b.length > 0 && (b[b.length - 1] >> 7) == 1
+    let aIsNeg = a.length > 0 && (a[a.length - 1] >> 7) == 1
+    let bIsIneg = b.length > 0 && (b[b.length - 1] >> 7) == 1
     
-    if (!a_is_neg && b_is_neg) {
+    if (!aIsNeg && bIsIneg) {
       return 1
-    } else if (a_is_neg && !b_is_neg) {
+    } else if (aIsNeg && !bIsIneg) {
       return -1
     }
     
     // Check how many bytes of a and b are relevant to the magnitude.
-    let a_relevant_bytes = a.length;
-    while(a_relevant_bytes > 0 &&
-      (!a_is_neg && a[a_relevant_bytes - 1] == 0 ||
-      a_is_neg && a[a_relevant_bytes - 1] == 255)) {
-        a_relevant_bytes -= 1;
+    let aRelevantBytes = a.length;
+    while(aRelevantBytes > 0 &&
+      (!aIsNeg && a[aRelevantBytes - 1] == 0 ||
+      aIsNeg && a[aRelevantBytes - 1] == 255)) {
+        aRelevantBytes -= 1;
     }
-    let b_relevant_bytes = b.length;
-    while(b_relevant_bytes > 0 &&
-      (!b_is_neg && b[b_relevant_bytes - 1] == 0 ||
-      b_is_neg && b[b_relevant_bytes - 1] == 255)) {
-        b_relevant_bytes -= 1;
+    let bRelevantBytes = b.length;
+    while(bRelevantBytes > 0 &&
+      (!bIsIneg && b[(bRelevantBytes) - 1] == 0 ||
+      bIsIneg && b[bRelevantBytes - 1] == 255)) {
+        bRelevantBytes -= 1;
     }
 
     // If a and b are positive then the one with more relevant bytes is larger.
     // Otherwise the one with less relevant bytes is larger.
-    if (a_relevant_bytes > b_relevant_bytes) {
-        return a_is_neg ? -1 : 1;
-    } else if (b_relevant_bytes > a_relevant_bytes) {
-        return a_is_neg ? 1 : -1;
+    if (aRelevantBytes > bRelevantBytes) {
+        return aIsNeg ? -1 : 1;
+    } else if (bRelevantBytes > aRelevantBytes) {
+        return aIsNeg ? 1 : -1;
     }
  
     // We now know that a and b have the same sign and number of relevant bytes.
     // If a and b are both negative then the one of lesser magnitude is the
     // largest, however since in two's complement the magnitude is flipped, we
     // may use the same logic as if a and are positive.
-    let shortest_length = a.length < b.length ? a.length : b.length;
-    for(let i = shortest_length - 2; i >= 0; i--) {
+    let shortestLength = a.length < b.length ? a.length : b.length;
+    for(let i = shortestLength - 2; i >= 0; i--) {
       if (a[i] < b[i]) {
           return  -1
       } else if (a[i] > b[i]) {

--- a/index.ts
+++ b/index.ts
@@ -158,6 +158,18 @@ export class ByteArray extends Uint8Array {
     self[3] = (x >> 24) as u8
     return self
   }
+  
+  static fromHexString(hex: string): Bytes {
+    // Skip possible `0x` prefix.
+    if (hex.length >= 2 && hex[0] == '0' && hex[1] == 'x') {
+      hex = hex.substr(2)
+    }
+    let output = new Bytes(hex.length / 2);
+    for (let i = 0; i < hex.length; i += 2) {
+      output[i / 2] = I8.parseInt(hex.substr(i, 2), 16);
+    }
+    return output;
+  }
 
   toHex(): string {
     return typeConversion.bytesToHex(this)

--- a/index.ts
+++ b/index.ts
@@ -200,6 +200,16 @@ export class BigInt extends Uint8Array {
     return bytes as Uint8Array as BigInt
   }
 
+  /// `bytes` assumed to be little-endian.
+  static fromUnsignedBytes(bytes: Bytes): BigInt {
+    let signed_bytes = new BigInt(bytes.length + 1);
+    for (let i = 0; i < bytes.length; i++) {
+      signed_bytes[i] = bytes[i]
+    }
+    signed_bytes[bytes.length] = 0
+    return signed_bytes
+  }
+
   toHex(): string {
     return typeConversion.bigIntToHex(this)
   }

--- a/index.ts
+++ b/index.ts
@@ -177,6 +177,24 @@ export class ByteArray extends Uint8Array {
   toBase58(): string {
     return typeConversion.bytesToBase58(this)
   }
+
+  /// Interprets the first 4 bytes as a little-endian U32.
+  toU32(): u32 {
+    let padded_bytes = new Bytes(4);
+    padded_bytes[0] = 0;
+    padded_bytes[1] = 0;
+    padded_bytes[2] = 0;
+    padded_bytes[3] = 0;
+    for (let i = 0; i < this.length; i++) {
+      padded_bytes[i] = this[i]
+    }
+    let x: u32 = 0;
+    x = (x | padded_bytes[3]) << 8;
+    x = (x | padded_bytes[2]) << 8;
+    x = (x | padded_bytes[1]) << 8;
+    x = (x | padded_bytes[0]);
+    return x;
+  }
 }
 
 /** A dynamically-sized byte array. */
@@ -195,12 +213,12 @@ export class BigInt extends Uint8Array {
     return ByteArray.fromI32(x) as Uint8Array as BigInt
   }
 
-  /// `bytes` assumed to be little-endian.
+  /// `bytes` assumed to be little-endian. If your input is big-endian, call `.reverse()` first.
   static fromSignedBytes(bytes: Bytes): BigInt {
     return bytes as Uint8Array as BigInt
   }
 
-  /// `bytes` assumed to be little-endian.
+  /// `bytes` assumed to be little-endian. If your input is big-endian, call `.reverse()` first.
   static fromUnsignedBytes(bytes: Bytes): BigInt {
     let signed_bytes = new BigInt(bytes.length + 1);
     for (let i = 0; i < bytes.length; i++) {

--- a/index.ts
+++ b/index.ts
@@ -149,7 +149,9 @@ export class TypedMap<K, V> {
  * Byte array
  */
 export class ByteArray extends Uint8Array {
-  /// Returns bytes in little-endian order.
+  /**
+   * Returns bytes in little-endian order.
+   */
   static fromI32(x: i32): ByteArray {
     let self = new ByteArray(4)
     self[0] = x as u8
@@ -159,7 +161,11 @@ export class ByteArray extends Uint8Array {
     return self
   }
   
+  /**
+   * Input length must be even.
+   */
   static fromHexString(hex: string): Bytes {
+    assert(hex.length % 2 == 0, "input " + hex + " has odd length");
     // Skip possible `0x` prefix.
     if (hex.length >= 2 && hex[0] == '0' && hex[1] == 'x') {
       hex = hex.substr(2)
@@ -187,8 +193,10 @@ export class ByteArray extends Uint8Array {
     return typeConversion.bytesToBase58(this)
   }
 
-  /// Interprets the byte array as a little-endian U32.
-  /// Fails in case of overflow.
+  /**
+   * Interprets the byte array as a little-endian U32.
+   * Throws in case of overflow.
+   */ 
   toU32(): u32 {
     for (let i = 4; i < this.length; i++) {
       if (this[i] != 0) {
@@ -212,8 +220,10 @@ export class ByteArray extends Uint8Array {
     return x;
   }
 
-  /// Interprets the byte array as a little-endian I32.
-  /// Fails in case of overflow.
+  /**
+   * Interprets the byte array as a little-endian I32.
+   * Throws in case of overflow.
+   */ 
   toI32(): i32 {
     let is_neg = this.length > 0 && (this[this.length - 1] >> 7) == 1;
     let padding = is_neg ? 255 : 0;
@@ -256,12 +266,16 @@ export class BigInt extends Uint8Array {
     return ByteArray.fromI32(x) as Uint8Array as BigInt
   }
 
-  /// `bytes` assumed to be little-endian. If your input is big-endian, call `.reverse()` first.
+  /**
+   * `bytes` assumed to be little-endian. If your input is big-endian, call `.reverse()` first.
+   */ 
   static fromSignedBytes(bytes: Bytes): BigInt {
     return bytes as Uint8Array as BigInt
   }
 
-  /// `bytes` assumed to be little-endian. If your input is big-endian, call `.reverse()` first.
+  /**
+   * `bytes` assumed to be little-endian. If your input is big-endian, call `.reverse()` first.
+   */ 
   static fromUnsignedBytes(bytes: Bytes): BigInt {
     let signed_bytes = new BigInt(bytes.length + 1);
     for (let i = 0; i < bytes.length; i++) {
@@ -369,7 +383,9 @@ export class BigInt extends Uint8Array {
     return BigInt.fromI32(0) - this
   }
 
-  /// Returns −1 if a < b, 1 if a > b, and 0 if A == B
+  /**
+   * Returns −1 if a < b, 1 if a > b, and 0 if A == B
+   */
   static compare(a: BigInt, b: BigInt): i32 {
     // Check if a and b have the same sign.
     let a_is_neg = a.length > 0 && (a[a.length - 1] >> 7) == 1

--- a/index.ts
+++ b/index.ts
@@ -182,6 +182,11 @@ export class Address extends Bytes {
 
 /** An arbitrary size integer represented as an array of bytes. */
 export class BigInt extends Uint8Array {
+  /// `bytes` assumed to be little-endian.
+  static fromSignedBytes(bytes: Bytes): BigInt {
+    return bytes as Uint8Array as BigInt
+  }
+
   toHex(): string {
     return typeConversion.bigIntToHex(this)
   }
@@ -201,6 +206,25 @@ export class BigInt extends Uint8Array {
   toI32(): i32 {
     return typeConversion.bigIntToI32(this)
   }
+
+  toBigDecimal(): BigDecimal {
+    return new BigDecimal(this)
+  }
+
+  isZero(): boolean {
+    for (let i = 0; i < this.length; i++) {
+      if (this[i] != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  isI32(): boolean {
+    return BigInt.fromI32(i32.MIN_VALUE) <= this && this <= BigInt.fromI32(i32.MAX_VALUE)
+  }
+
+  // Operators
 
   @operator('+')
   plus(other: BigInt): BigInt {
@@ -243,9 +267,34 @@ export class BigInt extends Uint8Array {
     }
     return true;
   }
-  
-  toBigDecimal(): BigDecimal {
-    return new BigDecimal(this)
+
+  @operator('!=')
+  not_equal(other: BigInt): boolean {
+    return !(this == other)
+  }
+
+  @operator('<')
+  lt(other: BigInt): boolean {
+    // If the subtraction is negative, `other` is larger.
+    let diff = this - other;
+    return (diff[0] >> 7) == 1
+  }
+
+  @operator('>')
+  gt(other: BigInt): boolean {
+    // If not equal and the subtraction is not negative, `other` is smaller.
+    let diff = this - other;
+    return this != other && (diff[0] >> 7) == 1
+  }
+
+  @operator('<=')
+  le(other: BigInt): boolean {
+    return !(this > other)
+  }
+
+  @operator('>=')
+  ge(other: BigInt): boolean {
+    return !(this < other)
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,10 @@ try {
   let test_wasm = new Uint8Array(fs.readFileSync(output_path))
  
   WebAssembly.instantiate(test_wasm, {
-    env
+    env,
+    index: {
+      "typeConversion.bytesToHex": function() {}
+    }
   }).then(module => {
     module.instance.exports.test();
   });

--- a/test/test.ts
+++ b/test/test.ts
@@ -75,4 +75,14 @@ export function test(): void {
     long_array[4] = 0
     assert(long_array.toU32() == 4294705147)
     assert(long_array.toI32() == 4294705147)
+
+    let bytes = Bytes.fromHexString("0x56696b746f726961")
+    assert(bytes[0] = 0x56)
+    assert(bytes[1] = 0x69)
+    assert(bytes[2] = 0x6b)
+    assert(bytes[3] = 0x74)
+    assert(bytes[4] = 0x6f)
+    assert(bytes[5] = 0x72)
+    assert(bytes[6] = 0x69)
+    assert(bytes[7] = 0x61)
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -5,6 +5,7 @@ export function test(): void {
     let minus_five_bytes = new ByteArray(2)
     minus_five_bytes[0] = 251
     minus_five_bytes[1] = 255
+    assert(minus_five_bytes.toU32() == 65531)
     let minus_five = BigInt.fromSignedBytes(minus_five_bytes as Bytes)
     assert(minus_five.isI32())
     assert(minus_five == BigInt.fromI32(-5))
@@ -18,6 +19,7 @@ export function test(): void {
     assert(five == BigInt.fromI32(5))
     assert(five != minus_five)
     assert(five == BigInt.fromUnsignedBytes(five_bytes.subarray(0, 1) as Bytes))
+    assert(five_bytes.toU32() == 5)
 
     let x = new ByteArray(1)
     x[0] = 255

--- a/test/test.ts
+++ b/test/test.ts
@@ -66,6 +66,18 @@ export function test(): void {
     b = BigInt.fromI32(900)
     assert(b < a && b <= a)
 
+    a = BigInt.fromI32(123)
+    b = BigInt.fromI32(124)
+    assert(a < b && a <= b)
+    assert(b > a && b >= a)
+
+    a = BigInt.fromI32(I32.MIN_VALUE)
+    b = BigInt.fromI32(I32.MAX_VALUE)
+    assert(a < b && a <= b)
+    assert(b > a && b >= a)
+    assert(a.toI32() == -2147483648)
+    assert(b.toI32() == 2147483647)
+
     let longArray = new ByteArray(5)
     longArray[0] = 251
     longArray[1] = 255

--- a/test/test.ts
+++ b/test/test.ts
@@ -5,11 +5,12 @@ export function test(): void {
     let minus_five_bytes = new ByteArray(2)
     minus_five_bytes[0] = 251
     minus_five_bytes[1] = 255
-    assert(minus_five_bytes.toU32() == 65531)
     let minus_five = BigInt.fromSignedBytes(minus_five_bytes as Bytes)
     assert(minus_five.isI32())
     assert(minus_five == BigInt.fromI32(-5))
     assert(!minus_five.isZero() && minus_five.isI32())
+    assert(minus_five_bytes.toU32() == 65531)
+    assert(minus_five_bytes.toI32() == -5)
 
     let five_bytes = new ByteArray(2)
     five_bytes[0] = 5
@@ -20,42 +21,58 @@ export function test(): void {
     assert(five != minus_five)
     assert(five == BigInt.fromUnsignedBytes(five_bytes.subarray(0, 1) as Bytes))
     assert(five_bytes.toU32() == 5)
+    assert(five_bytes.toI32() == 5)
 
     let x = new ByteArray(1)
     x[0] = 255
     assert(BigInt.fromUnsignedBytes(x as Bytes) == BigInt.fromI32(255))
-
+    
     let zero = BigInt.fromSignedBytes(new ByteArray(0) as Bytes)
     assert(zero.isZero() && zero.isI32())
     assert(zero != five)
     assert(zero != minus_five)
     assert(minus_five < zero && minus_five <= zero)
     assert(five > zero && five >= zero)
-
-    let a = BigInt.fromI32(77123455)
-    assert(a == a && a.isI32())
-
-    let b = BigInt.fromI32(48294181)
-    assert(b == b && b.isI32())
+    
+    let a_i32 = 77123455
+    let a = BigInt.fromI32(a_i32)
+    assert(a == a && a.isI32() && a.toI32() == a_i32)
+    
+    let b_i32 = 48294181
+    let b = BigInt.fromI32(b_i32)
+    assert(b == b && b.isI32() && b.toI32() == b_i32)
     assert(a < b && a <= b)
-
+    
+    a_i32 = 9292928
     a = BigInt.fromI32(9292928)
-    assert(a == a && a.isI32())
+    assert(a == a && a.isI32() && a.toI32() == a_i32)
     assert(a < b && a <= b)
-
-    b = BigInt.fromI32(-9717735)
-    assert(b == b && b.isI32())
+    
+    b_i32 = -9717735
+    b = BigInt.fromI32(b_i32)
+    assert(b == b && b.isI32() && b.toI32() == b_i32)
     assert(b < a && b <= a)
-
-    a = BigInt.fromI32(53499369)
-    assert(a == a && a.isI32())
+    
+    a_i32 = 53499369
+    a = BigInt.fromI32(a_i32)
+    assert(a == a && a.isI32() && a.toI32() == a_i32)
     assert(b < a && b <= a)
-
-    b = BigInt.fromI32(10242178)
-    assert(b == b && b.isI32())
+    
+    b_i32 = 10242178
+    b = BigInt.fromI32(b_i32)
+    assert(b == b && b.isI32() && b.toI32() == b_i32)
     assert(b < a && b <= a)
-
+    
     a = BigInt.fromI32(1000)
     b = BigInt.fromI32(900)
     assert(b < a && b <= a)
+
+    let long_array = new ByteArray(5)
+    long_array[0] = 251
+    long_array[1] = 255
+    long_array[2] = 251
+    long_array[3] = 255
+    long_array[4] = 0
+    assert(long_array.toU32() == 4294705147)
+    assert(long_array.toI32() == 4294705147)
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -17,6 +17,11 @@ export function test(): void {
     assert(!five.isZero() && five.isI32())
     assert(five == BigInt.fromI32(5))
     assert(five != minus_five)
+    assert(five == BigInt.fromUnsignedBytes(five_bytes.subarray(0, 1) as Bytes))
+
+    let x = new ByteArray(1)
+    x[0] = 255
+    assert(BigInt.fromUnsignedBytes(x as Bytes) == BigInt.fromI32(255))
 
     let zero = BigInt.fromSignedBytes(new ByteArray(0) as Bytes)
     assert(zero.isZero() && zero.isI32())

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,7 +1,14 @@
-import { ByteArray } from 'temp_lib/index'
+import { BigInt, ByteArray, Bytes } from 'temp_lib/index'
 
-// `export` so this isn't considered dead code.
-export function foo(): void {
-    let a = new ByteArray(0)
-    let b: string = a.toBase58()
+// Test some BigInt methods.
+export function test(): void {
+    let bytes = new ByteArray(4)
+    bytes[0] = 5
+    bytes[1] = 0
+    let five = BigInt.fromSignedBytes(bytes as Bytes)
+    assert(!five.isZero())
+
+    let zero = BigInt.fromSignedBytes(new ByteArray(0) as Bytes)
+    assert(zero.isZero())
+    assert(zero != five)
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -24,4 +24,31 @@ export function test(): void {
     assert(zero != minus_five)
     assert(minus_five < zero && minus_five <= zero)
     assert(five > zero && five >= zero)
+
+    let a = BigInt.fromI32(77123455)
+    assert(a == a && a.isI32())
+
+    let b = BigInt.fromI32(48294181)
+    assert(b == b && b.isI32())
+    assert(a < b && a <= b)
+
+    a = BigInt.fromI32(9292928)
+    assert(a == a && a.isI32())
+    assert(a < b && a <= b)
+
+    b = BigInt.fromI32(-9717735)
+    assert(b == b && b.isI32())
+    assert(b < a && b <= a)
+
+    a = BigInt.fromI32(53499369)
+    assert(a == a && a.isI32())
+    assert(b < a && b <= a)
+
+    b = BigInt.fromI32(10242178)
+    assert(b == b && b.isI32())
+    assert(b < a && b <= a)
+
+    a = BigInt.fromI32(1000)
+    b = BigInt.fromI32(900)
+    assert(b < a && b <= a)
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,13 +2,26 @@ import { BigInt, ByteArray, Bytes } from 'temp_lib/index'
 
 // Test some BigInt methods.
 export function test(): void {
-    let bytes = new ByteArray(4)
-    bytes[0] = 5
-    bytes[1] = 0
-    let five = BigInt.fromSignedBytes(bytes as Bytes)
-    assert(!five.isZero())
+    let minus_five_bytes = new ByteArray(2)
+    minus_five_bytes[0] = 251
+    minus_five_bytes[1] = 255
+    let minus_five = BigInt.fromSignedBytes(minus_five_bytes as Bytes)
+    assert(minus_five.isI32())
+    assert(minus_five == BigInt.fromI32(-5))
+    assert(!minus_five.isZero() && minus_five.isI32())
+
+    let five_bytes = new ByteArray(2)
+    five_bytes[0] = 5
+    five_bytes[1] = 0
+    let five = BigInt.fromSignedBytes(five_bytes as Bytes)
+    assert(!five.isZero() && five.isI32())
+    assert(five == BigInt.fromI32(5))
+    assert(five != minus_five)
 
     let zero = BigInt.fromSignedBytes(new ByteArray(0) as Bytes)
-    assert(zero.isZero())
+    assert(zero.isZero() && zero.isI32())
     assert(zero != five)
+    assert(zero != minus_five)
+    assert(minus_five < zero && minus_five <= zero)
+    assert(five > zero && five >= zero)
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,26 +2,25 @@ import { BigInt, ByteArray, Bytes } from 'temp_lib/index'
 
 // Test some BigInt methods.
 export function test(): void {
-    let minus_five_bytes = new ByteArray(2)
-    minus_five_bytes[0] = 251
-    minus_five_bytes[1] = 255
-    let minus_five = BigInt.fromSignedBytes(minus_five_bytes as Bytes)
-    assert(minus_five.isI32())
-    assert(minus_five == BigInt.fromI32(-5))
-    assert(!minus_five.isZero() && minus_five.isI32())
-    assert(minus_five_bytes.toU32() == 65531)
-    assert(minus_five_bytes.toI32() == -5)
+    let minusFiveBytes = new ByteArray(2)
+    minusFiveBytes[0] = 251
+    minusFiveBytes[1] = 255
+    let minusFive = BigInt.fromSignedBytes(minusFiveBytes as Bytes)
+    assert(minusFive == BigInt.fromI32(-5))
+    assert(!minusFive.isZero() && minusFive.isI32())
+    assert(minusFiveBytes.toU32() == 65531)
+    assert(minusFiveBytes.toI32() == -5)
 
-    let five_bytes = new ByteArray(2)
-    five_bytes[0] = 5
-    five_bytes[1] = 0
-    let five = BigInt.fromSignedBytes(five_bytes as Bytes)
+    let fiveBytes = new ByteArray(2)
+    fiveBytes[0] = 5
+    fiveBytes[1] = 0
+    let five = BigInt.fromSignedBytes(fiveBytes as Bytes)
     assert(!five.isZero() && five.isI32())
     assert(five == BigInt.fromI32(5))
-    assert(five != minus_five)
-    assert(five == BigInt.fromUnsignedBytes(five_bytes.subarray(0, 1) as Bytes))
-    assert(five_bytes.toU32() == 5)
-    assert(five_bytes.toI32() == 5)
+    assert(five != minusFive)
+    assert(five == BigInt.fromUnsignedBytes(fiveBytes.subarray(0, 1) as Bytes))
+    assert(fiveBytes.toU32() == 5)
+    assert(fiveBytes.toI32() == 5)
 
     let x = new ByteArray(1)
     x[0] = 255
@@ -30,51 +29,51 @@ export function test(): void {
     let zero = BigInt.fromSignedBytes(new ByteArray(0) as Bytes)
     assert(zero.isZero() && zero.isI32())
     assert(zero != five)
-    assert(zero != minus_five)
-    assert(minus_five < zero && minus_five <= zero)
+    assert(zero != minusFive)
+    assert(minusFive < zero && minusFive <= zero)
     assert(five > zero && five >= zero)
     
-    let a_i32 = 77123455
-    let a = BigInt.fromI32(a_i32)
-    assert(a == a && a.isI32() && a.toI32() == a_i32)
+    let aI32 = 77123455
+    let a = BigInt.fromI32(aI32)
+    assert(a == a && a.isI32() && a.toI32() == aI32)
     
-    let b_i32 = 48294181
-    let b = BigInt.fromI32(b_i32)
-    assert(b == b && b.isI32() && b.toI32() == b_i32)
+    let bI32 = 48294181
+    let b = BigInt.fromI32(bI32)
+    assert(b == b && b.isI32() && b.toI32() == bI32)
     assert(a < b && a <= b)
     
-    a_i32 = 9292928
+    aI32 = 9292928
     a = BigInt.fromI32(9292928)
-    assert(a == a && a.isI32() && a.toI32() == a_i32)
+    assert(a == a && a.isI32() && a.toI32() == aI32)
     assert(a < b && a <= b)
     
-    b_i32 = -9717735
-    b = BigInt.fromI32(b_i32)
-    assert(b == b && b.isI32() && b.toI32() == b_i32)
+    bI32 = -9717735
+    b = BigInt.fromI32(bI32)
+    assert(b == b && b.isI32() && b.toI32() == bI32)
     assert(b < a && b <= a)
     
-    a_i32 = 53499369
-    a = BigInt.fromI32(a_i32)
-    assert(a == a && a.isI32() && a.toI32() == a_i32)
+    aI32 = 53499369
+    a = BigInt.fromI32(aI32)
+    assert(a == a && a.isI32() && a.toI32() == aI32)
     assert(b < a && b <= a)
     
-    b_i32 = 10242178
-    b = BigInt.fromI32(b_i32)
-    assert(b == b && b.isI32() && b.toI32() == b_i32)
+    bI32 = 10242178
+    b = BigInt.fromI32(bI32)
+    assert(b == b && b.isI32() && b.toI32() == bI32)
     assert(b < a && b <= a)
     
     a = BigInt.fromI32(1000)
     b = BigInt.fromI32(900)
     assert(b < a && b <= a)
 
-    let long_array = new ByteArray(5)
-    long_array[0] = 251
-    long_array[1] = 255
-    long_array[2] = 251
-    long_array[3] = 255
-    long_array[4] = 0
-    assert(long_array.toU32() == 4294705147)
-    assert(long_array.toI32() == 4294705147)
+    let longArray = new ByteArray(5)
+    longArray[0] = 251
+    longArray[1] = 255
+    longArray[2] = 251
+    longArray[3] = 255
+    longArray[4] = 0
+    assert(longArray.toU32() == 4294705147)
+    assert(longArray.toI32() == 4294705147)
 
     let bytes = Bytes.fromHexString("0x56696b746f726961")
     assert(bytes[0] = 0x56)


### PR DESCRIPTION
Resolves #35, resolves #47.

This adds the helpers requested in those issues. It also allows conversion between BigInt and i32 to be implemented without host imports.

A testing harness is added to test the AS implementations. For now it only supports one test file with one test function.