### PR TITLE
Add `log` module and `toString` utility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,11 +83,98 @@ declare namespace dataSource {
   function create(name: string, params: Array<string>): void
 }
 
-/** Special function for ENS name lookups, not meant for general purpose
- * use. This function will only be useful if the graph-node instance has
- * additional data loaded **/
+/**
+ * Special function for ENS name lookups, not meant for general purpose use.
+ * This function will only be useful if the graph-node instance has additional
+ * data loaded **
+ */
 export declare namespace ens {
-    function nameByHash(hash: string): string|null
+  function nameByHash(hash: string): string | null
+}
+
+function format(fmt: string, args: string[]): string {
+  let out = ''
+  let argIndex = 0
+  for (let i: i32 = 0, len: i32 = fmt.length; i < len; i++) {
+    if (
+      i < len - 1 &&
+      fmt.charCodeAt(i) == 0x7b /* '{' */ &&
+      fmt.charCodeAt(i + 1) == 0x7d /* '}' */
+    ) {
+      if (argIndex >= args.length) {
+        throw Error('Too few arguments for format string: ' + fmt)
+      } else {
+        out += args[argIndex++]
+        i++
+      }
+    } else {
+      out += fmt[i]
+    }
+  }
+  return out
+}
+
+// Host interface for logging
+export declare namespace log {
+  // Host export for logging, providing basic logging functionality
+  export function log(level: Level, msg: string): void
+}
+
+export namespace log {
+  export enum Level {
+    CRITICAL = 0,
+    ERROR = 1,
+    WARNING = 2,
+    INFO = 3,
+    DEBUG = 4,
+  }
+
+  /**
+   * Logs a critical message that terminates the subgraph.
+   *
+   * @param msg Format string a la "Value = {}, other = {}".
+   * @param args Format string arguments.
+   */
+  export function critical(msg: string, args: Array<string>): void {
+    log(Level.CRITICAL, format(msg, args))
+  }
+
+  /**
+   * Logs an error message.
+   *
+   * @param msg Format string a la "Value = {}, other = {}".
+   * @param args Format string arguments.
+   */
+  export function error(msg: string, args: Array<string>): void {
+    log(Level.ERROR, format(msg, args))
+  }
+
+  /** Logs a warning message.
+   *
+   * @param msg Format string a la "Value = {}, other = {}".
+   * @param args Format string arguments.
+   */
+  export function warning(msg: string, args: Array<string>): void {
+    log(Level.WARNING, format(msg, args))
+  }
+
+  /** Logs an info message.
+   *
+   * @param msg Format string a la "Value = {}, other = {}".
+   * @param args Format string arguments.
+   */
+  export function info(msg: string, args: Array<string>): void {
+    log(Level.INFO, format(msg, args))
+  }
+
+  /** Logs a debug message.
+   *
+   * @param msg Format string a la "Value = {}, other = {}".
+   * @param args Format string arguments.
+   */
+  export function debug(msg: string, args: Array<string>): void {
+    log(Level.DEBUG, format(msg, args))
+  }
 }
 
 /**


### PR DESCRIPTION
Resolves #5 and https://github.com/graphprotocol/graph-node/issues/599. Corresponding graph-node PR: https://github.com/graphprotocol/graph-node/pull/943.

The `log` module contains `critical`, `error`, `warning`, `info`
and `debug` functions that each take a format string a la

    "first value = {}, second value = {}"

and a string array with format string arguments. Due to limitations
in AssemblyScript, we can at this point not provide a more convenient
solution that converts arguments to strings behind the scenes.

## TODO

- [x] Add docs to thegraph.com/docs/