### PR TITLE
Big decimal comparisons

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -583,7 +583,100 @@ export class BigDecimal {
 
   @operator('==')
   equals(other: BigDecimal): boolean {
-    return bigDecimal.equals(this, other)
+    return BigDecimal.compare(this, other) == 0
+  }
+
+  @operator('!=')
+  notEqual(other: BigDecimal): boolean {
+    return !(this == other)
+  }
+
+  @operator('<')
+  lt(other: BigDecimal): boolean {
+    return BigDecimal.compare(this, other) == -1
+  }
+
+  @operator('>')
+  gt(other: BigDecimal): boolean {
+    return BigDecimal.compare(this, other) == 1
+  }
+
+  @operator('<=')
+  le(other: BigDecimal): boolean {
+    return !(this > other)
+  }
+
+  @operator('>=')
+  ge(other: BigDecimal): boolean {
+    return !(this < other)
+  }
+
+  @operator.prefix('-')
+  neg(): BigDecimal {
+    return new BigDecimal(new BigInt(0)) - this
+  }
+
+  /**
+   * Returns −1 if a < b, 1 if a > b, and 0 if A == B
+   */
+  static compare(a: BigDecimal, b: BigDecimal): i32 {
+    // Check if a and b have the same sign.
+    let aIsNeg = a.digits < new BigInt(0)
+    let bIsNeg = b.digits < new BigInt(0)
+
+    if (!aIsNeg && bIsNeg) {
+      return 1
+    } else if (aIsNeg && !bIsNeg) {
+      return -1
+    }
+
+    // Check how many digits of a and b are relevant to the magnitude.
+    let aRelevantDigits = a.digits.length
+    while (
+      aRelevantDigits > 0 &&
+      ((!aIsNeg && a.digits[aRelevantDigits - 1] == 0) ||
+        (aIsNeg && a.digits[aRelevantDigits - 1] == 255))
+    ) {
+      aRelevantDigits -= 1
+    }
+    let bRelevantDigits = b.digits.length
+    while (
+      bRelevantDigits > 0 &&
+      ((!bIsNeg && b.digits[bRelevantDigits - 1] == 0) ||
+        (bIsNeg && b.digits[bRelevantDigits - 1] == 255))
+    ) {
+      bRelevantDigits -= 1
+    }
+
+    let aTotalLength = BigInt.fromI32(aRelevantDigits as i32) + a.exp
+    let bTotalLength = BigInt.fromI32(bRelevantDigits as i32) + b.exp
+    
+    // If a and b are positive then the longer one is larger.
+    // Otherwise the shorter one is larger.
+    if (aTotalLength > bTotalLength) {
+      return aIsNeg ? -1 : 1
+    } else if (bTotalLength > aTotalLength) {
+      return aIsNeg ? 1 : -1
+    }
+    
+    // We now know that a and b have the same sign and total length. If a and b
+    // are both negative then the one of lesser magnitude is the largest,
+    // however since in two's complement the magnitude is flipped, we may use
+    // the same logic as if a and are positive.
+    //
+    // Compare from the most significant to the least significant byte, using 0
+    // for the bytes represented by the exponent, until one is larger.
+    for (let i = 0; i <= Math.max(aRelevantDigits, bRelevantDigits); i++) {
+      let aByte = aRelevantDigits > i ? a.digits[aRelevantDigits - 1 - i] : 0
+      let bByte = bRelevantDigits > i ? b.digits[bRelevantDigits - 1 - i] : 0
+      if (aByte < bByte) {
+        return -1
+      } else if (aByte > bByte) {
+        return 1
+      }
+    }
+  
+    return 0
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -478,11 +478,11 @@ export class BigInt extends Uint8Array {
   static compare(a: BigInt, b: BigInt): i32 {
     // Check if a and b have the same sign.
     let aIsNeg = a.length > 0 && a[a.length - 1] >> 7 == 1
-    let bIsIneg = b.length > 0 && b[b.length - 1] >> 7 == 1
+    let bIsNeg = b.length > 0 && b[b.length - 1] >> 7 == 1
 
-    if (!aIsNeg && bIsIneg) {
+    if (!aIsNeg && bIsNeg) {
       return 1
-    } else if (aIsNeg && !bIsIneg) {
+    } else if (aIsNeg && !bIsNeg) {
       return -1
     }
 
@@ -498,8 +498,8 @@ export class BigInt extends Uint8Array {
     let bRelevantBytes = b.length
     while (
       bRelevantBytes > 0 &&
-      ((!bIsIneg && b[bRelevantBytes - 1] == 0) ||
-        (bIsIneg && b[bRelevantBytes - 1] == 255))
+      ((!bIsNeg && b[bRelevantBytes - 1] == 0) ||
+        (bIsNeg && b[bRelevantBytes - 1] == 255))
     ) {
       bRelevantBytes -= 1
     }


### PR DESCRIPTION
Add comparison operators to BigDecimal, as we did to BigInt.

Because it depends on BigInt addition (which is imported from host), it cannot be tested directly, so I ran manual tests. Specifically I tested the following code:
```
    let y = new BigDecimal(BigInt.fromI32(-101));
    let z = new BigDecimal(BigInt.fromI32(100));
    assert(y < z && y <= z)

    y = new BigDecimal(BigInt.fromI32(101));
    assert(y > z && y >= z)

    y = new BigDecimal(BigInt.fromI32(1001));
    assert(y > z && y >= z)

    y = new BigDecimal(BigInt.fromI32(-1001));
    z = new BigDecimal(BigInt.fromI32(-101));
    assert(y < z && y <= z)

    z = new BigDecimal(BigInt.fromI32(-1001));
    assert(y == z && y >= z)
```

Resolves #67. Docs also need to be added.