### PR TITLE
Fix BigInt comparison

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -521,12 +521,12 @@ export class BigInt extends Uint8Array {
     // We now know that a and b have the same sign and number of relevant bytes.
     // If a and b are both negative then the one of lesser magnitude is the
     // largest, however since in two's complement the magnitude is flipped, we
-    // may use the same logic as if a and are positive.
-    let shortestLength = a.length < b.length ? a.length : b.length
-    for (let i = shortestLength - 2; i >= 0; i--) {
-      if (a[i] < b[i]) {
+    // may use the same logic as if a and b are positive.
+    let relevantBytes = aRelevantBytes
+    for (let i = 1; i <= relevantBytes; i++) {
+      if (a[relevantBytes - i] < b[relevantBytes - i]) {
         return -1
-      } else if (a[i] > b[i]) {
+      } else if (a[relevantBytes - i] > b[relevantBytes - i]) {
         return 1
       }
     }

--- a/test/test.ts
+++ b/test/test.ts
@@ -40,7 +40,7 @@ export function test(): void {
     let bI32 = 48294181
     let b = BigInt.fromI32(bI32)
     assert(b == b && b.isI32() && b.toI32() == bI32)
-    assert(a < b && a <= b)
+    assert(b < a && b <= a)
     
     aI32 = 9292928
     a = BigInt.fromI32(9292928)
@@ -77,6 +77,15 @@ export function test(): void {
     assert(b > a && b >= a)
     assert(a.toI32() == -2147483648)
     assert(b.toI32() == 2147483647)
+
+    // This is 8071860 in binary.
+    let blockNumber = new ByteArray(3)
+    blockNumber[0] = 180
+    blockNumber[1] = 42
+    blockNumber[2] = 123
+    let blockNumberBigInt = blockNumber as BigInt
+    let latestBlock = BigInt.fromI32(8200001)
+    assert(!blockNumberBigInt.gt(latestBlock))
 
     let longArray = new ByteArray(5)
     longArray[0] = 251


### PR DESCRIPTION
The bug affected numbers that had a different amount of trailing insignificant bytes. Interestingly this affects an existing test which was effectively testing the bug 🤦‍♂ 