### PR TITLE
Add conversion methods for Tuple arrays (ABIEncoderV2)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -767,14 +767,14 @@ export class EthereumValue {
     return changetype<EthereumTuple>(this.data as u32)
   }
 
-  toTupleArray(): Array<EthereumTuple> {
+  toTupleArray<T extends EthereumTuple>(): Array<T> {
     assert(this.kind == EthereumValueKind.ARRAY || this.kind == EthereumValueKind.FIXED_ARRAY,
       'EthereumValue is not an array.'
     )
     let valueArray = this.toArray()
-    let out = new Array<EthereumTuple>(valueArray.length)
+    let out = new Array<T>(valueArray.length)
     for (let i: i32 = 0; i < valueArray.length; i++) {
-      out[i] = valueArray[i].toTuple()
+      out[i] = valueArray[i].toTuple() as T
     }
     return out
   }

--- a/index.ts
+++ b/index.ts
@@ -767,6 +767,18 @@ export class EthereumValue {
     return changetype<EthereumTuple>(this.data as u32)
   }
 
+  toTupleArray(): Array<EthereumTuple> {
+    assert(this.kind == EthereumValueKind.ARRAY || this.kind == EthereumValueKind.FIXED_ARRAY,
+      'EthereumValue is not an array.'
+    )
+    let valueArray = this.toArray()
+    let out = new Array<EthereumTuple>(valueArray.length)
+    for (let i: i32 = 0; i < valueArray.length; i++) {
+      out[i] = valueArray[i].toTuple()
+    }
+    return out
+  }
+
   toBooleanArray(): Array<boolean> {
     assert(
       this.kind == EthereumValueKind.ARRAY || this.kind == EthereumValueKind.FIXED_ARRAY,
@@ -915,6 +927,14 @@ export class EthereumValue {
     token.kind = EthereumValueKind.TUPLE
     token.data = values as u64
     return token
+  }
+
+  static fromTupleArray(values: Array<EthereumTuple>): EthereumValue {
+    let out = new Array<EthereumValue>(values.length)
+    for(let i: i32 = 0; i < values.length; i++) {
+      out[i] = EthereumValue.fromTuple(values[i])
+    }
+    return EthereumValue.fromArray(out)
   }
 
   static fromBooleanArray(values: Array<boolean>): EthereumValue {


### PR DESCRIPTION
Resolves #72 

This PR is part of the greater goal of adding support for Tuple arrays along with [adding Tuple array codegen in graph-cli](https://github.com/graphprotocol/graph-cli/issues/316). 
Here we add conversion methods,`toTupleArray()` and `fromTupleArray()`,  to the `EthereumValue` class.


_Note: This PR is currently in the draft state because there has not been sufficient testing with a live subgraph_