### PR TITLE
Expose reverts to mappings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ export declare namespace store {
 
 /** Host Ethereum interface */
 declare namespace ethereum {
-  function call(call: SmartContractCall): Array<EthereumValue>
+  function call(call: SmartContractCall): Array<EthereumValue> | null
 }
 
 /** Host IPFS interface */
@@ -1381,7 +1381,10 @@ export class SmartContract {
 
   call(name: string, params: Array<EthereumValue>): Array<EthereumValue> {
     let call = new SmartContractCall(this._name, this._address, name, params)
-    return ethereum.call(call)
+    let result = ethereum.call(call)
+    assert(result != null, 'Call reverted, consider using `try_' + name + 
+                           '` to handle this in the mapping.')
+    return ethereum.call(call) as Array<EthereumValue>
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1385,7 +1385,8 @@ export class SmartContract {
     let result = ethereum.call(call)
     assert(
       result != null,
-      'Call reverted, consider using `try_' + name + '` to handle this in the mapping.',
+      'Call reverted, probably because an `assert` or `require` in the contract failed, ' +
+      'consider using `try_' + name + '` to handle this in the mapping.',
     )
     return ethereum.call(call) as Array<EthereumValue>
   }


### PR DESCRIPTION
Part of https://github.com/graphprotocol/graph-node/issues/1120.

First, the `call` host export may now return `null`, flagging a revert. `SmartContract.call` will check for null and fail the subgraph with a helpful error message. `SmartContract.tryCall` is new and returns a `CallResult`, allowing the mapping to handle a revert. The `CallResult` API changed a bit from the plan but does the same thing.