### PR TITLE
Don't perform contract calls twice (#76)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1408,7 +1408,7 @@ export class SmartContract {
         name +
         '` to handle this in the mapping.',
     )
-    return ethereum.call(call) as Array<EthereumValue>
+    return result as Array<EthereumValue>
   }
 
   tryCall(name: string, params: Array<EthereumValue>): CallResult<Array<EthereumValue>> {


### PR DESCRIPTION
The `call` method accidentally called `ethereum.call()` twice. The second time is unnecessary as the result is already available from the first call.