### PR TITLE
Add `BytesFromUTF8` helper

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1018,3 +1018,14 @@ export class Wrapped<T> {
     this.inner = inner
   }
 }
+
+export function stringToUTF8(string: String): ByteArray {
+  // AssemblyScript counts a null terminator, we don't want that.
+  let len = string.lengthUTF8 - 1;
+  let utf8 = string.toUTF8();
+  let bytes = new ByteArray(len);
+  for (let i: i32 = 0; i < len; i++) {
+    bytes[i] = load<u8>(utf8 + i)
+  }
+  return bytes;
+}

--- a/index.ts
+++ b/index.ts
@@ -265,6 +265,17 @@ export class ByteArray extends Uint8Array {
     return output
   }
 
+  static fromUTF8(string: String): ByteArray {
+      // AssemblyScript counts a null terminator, we don't want that.
+      let len = string.lengthUTF8 - 1;
+      let utf8 = string.toUTF8();
+      let bytes = new ByteArray(len);
+      for (let i: i32 = 0; i < len; i++) {
+        bytes[i] = load<u8>(utf8 + i)
+      }
+      return bytes;
+  }
+
   toHex(): string {
     return typeConversion.bytesToHex(this)
   }
@@ -1017,15 +1028,4 @@ export class Wrapped<T> {
   constructor(inner: T) {
     this.inner = inner
   }
-}
-
-export function stringToUTF8(string: String): ByteArray {
-  // AssemblyScript counts a null terminator, we don't want that.
-  let len = string.lengthUTF8 - 1;
-  let utf8 = string.toUTF8();
-  let bytes = new ByteArray(len);
-  for (let i: i32 = 0; i < len; i++) {
-    bytes[i] = load<u8>(utf8 + i)
-  }
-  return bytes;
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,4 @@
-import { BigInt, ByteArray, Bytes, stringToUTF8 } from 'temp_lib/index'
+import { BigInt, ByteArray, Bytes } from 'temp_lib/index'
 
 // Test some BigInt methods.
 export function test(): void {
@@ -109,5 +109,5 @@ export function test(): void {
     assert(ByteArray.fromI32(1) == ByteArray.fromI32(1))
     assert(ByteArray.fromI32(1) != ByteArray.fromI32(2))
 
-    assert(stringToUTF8("Hello, World!") == ByteArray.fromHexString("0x48656c6c6f2c20576f726c6421"))
+    assert(Bytes.fromUTF8("Hello, World!") == ByteArray.fromHexString("0x48656c6c6f2c20576f726c6421"))
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,4 @@
-import { BigInt, ByteArray, Bytes } from 'temp_lib/index'
+import { BigInt, ByteArray, Bytes, stringToUTF8 } from 'temp_lib/index'
 
 // Test some BigInt methods.
 export function test(): void {
@@ -86,4 +86,28 @@ export function test(): void {
     let blockNumberBigInt = blockNumber as BigInt
     let latestBlock = BigInt.fromI32(8200001)
     assert(!blockNumberBigInt.gt(latestBlock))
+
+    let longArray = new ByteArray(5)
+    longArray[0] = 251
+    longArray[1] = 255
+    longArray[2] = 251
+    longArray[3] = 255
+    longArray[4] = 0
+    assert(longArray.toU32() == 4294705147)
+    assert(longArray.toI32() == 4294705147)
+
+    let bytes = Bytes.fromHexString("0x56696b746f726961")
+    assert(bytes[0] = 0x56)
+    assert(bytes[1] = 0x69)
+    assert(bytes[2] = 0x6b)
+    assert(bytes[3] = 0x74)
+    assert(bytes[4] = 0x6f)
+    assert(bytes[5] = 0x72)
+    assert(bytes[6] = 0x69)
+    assert(bytes[7] = 0x61)
+
+    assert(ByteArray.fromI32(1) == ByteArray.fromI32(1))
+    assert(ByteArray.fromI32(1) != ByteArray.fromI32(2))
+
+    assert(stringToUTF8("Hello, World!") == ByteArray.fromHexString("0x48656c6c6f2c20576f726c6421"))
 }


### PR DESCRIPTION
Useful to replicate Solidity's `keccak256(abi.encodePacked(string))`, for example.