### PR TITLE
Add `json.try_fromBytes` support for handling JSON parsing errors

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ export declare namespace crypto {
 /** Host JSON interface */
 export declare namespace json {
   function fromBytes(data: Bytes): JSONValue
-  function try_fromBytes(data: Bytes): Result<JSONValue, JSONError>
+  function try_fromBytes(data: Bytes): Result<JSONValue, boolean>
   function toI64(decimal: string): i64
   function toU64(decimal: string): u64
   function toF64(decimal: string): f64
@@ -1091,12 +1091,6 @@ export class JSONValue {
     assert(this.kind == JSONValueKind.OBJECT, 'JSON value is not an object.')
     return changetype<TypedMap<string, JSONValue>>(this.data as u32)
   }
-}
-
-export class JSONError {
-  public line: u32
-  public column: u32
-  public message: string
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -32,11 +32,22 @@ export declare namespace crypto {
 
 /** Host JSON interface */
 export declare namespace json {
-  function fromBytes(data: Bytes): JSONValue
+  function try_fromBytes(data: Bytes): Result<JSONValue, JSONError>
   function toI64(decimal: string): i64
   function toU64(decimal: string): u64
   function toF64(decimal: string): f64
   function toBigInt(decimal: string): BigInt
+}
+
+export namespace json {
+  export function fromBytes(data: Bytes): JSONValue {
+    let result = json.try_fromBytes(data)
+    if (result.error !== null) {
+      throw result.error
+    } else {
+      return result.value
+    }
+  }
 }
 
 /** Host type conversion interface */
@@ -1082,6 +1093,12 @@ export class JSONValue {
     assert(this.kind == JSONValueKind.OBJECT, 'JSON value is not an object.')
     return changetype<TypedMap<string, JSONValue>>(this.data as u32)
   }
+}
+
+export class JSONError {
+  public line: u32
+  public column: u32
+  public message: string
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -181,6 +181,24 @@ export namespace log {
 }
 
 /**
+ * The result of an operation, with a corresponding value and error type.
+ */
+export class Result<V, E> {
+  public value: V | null
+  public error: E | null
+
+  unwrap(): V {
+    assert(this.value !== null, 'Called `Result::unwrap` on an error value')
+    return this.value as V
+  }
+
+  unwrapError(): E {
+    assert(this.error !== null, 'Called `Result::unwrapError` on a successful value')
+    return this.error as E
+  }
+}
+
+/**
  * TypedMap entry.
  */
 export class TypedMapEntry<K, V> {

--- a/index.ts
+++ b/index.ts
@@ -32,22 +32,12 @@ export declare namespace crypto {
 
 /** Host JSON interface */
 export declare namespace json {
+  function fromBytes(data: Bytes): JSONValue
   function try_fromBytes(data: Bytes): Result<JSONValue, JSONError>
   function toI64(decimal: string): i64
   function toU64(decimal: string): u64
   function toF64(decimal: string): f64
   function toBigInt(decimal: string): BigInt
-}
-
-export namespace json {
-  export function fromBytes(data: Bytes): JSONValue {
-    let result = json.try_fromBytes(data)
-    if (result.error !== null) {
-      throw result.error
-    } else {
-      return result.value
-    }
-  }
 }
 
 /** Host type conversion interface */

--- a/index.ts
+++ b/index.ts
@@ -185,17 +185,25 @@ export namespace log {
  * The result of an operation, with a corresponding value and error type.
  */
 export class Result<V, E> {
-  public value: V | null
-  public error: E | null
+  _value: Wrapped<V> | null
+  _error: Wrapped<E> | null
 
-  unwrap(): V {
-    assert(this.value !== null, 'Called `Result::unwrap` on an error value')
-    return this.value as V
+  get isOk(): boolean {
+    return this._value !== null
   }
 
-  unwrapError(): E {
-    assert(this.error !== null, 'Called `Result::unwrapError` on a successful value')
-    return this.error as E
+  get isError(): boolean {
+    return this._error !== null
+  }
+
+  get value(): V {
+    assert(this._value != null, 'Trying to get a value from an error result')
+    return (this._value as Wrapped<V>).inner
+  }
+
+  get error(): E {
+    assert(this._error != null, 'Trying to get an error from a successful result')
+    return (this._error as Wrapped<E>).inner
   }
 }
 


### PR DESCRIPTION
Part of resolving graphprotocol/graph-node#1577.

This changes the JSON host exports to be:
```ts
export declare namespace json {
  function fromBytes(data: Bytes): JSONValue
  function try_fromBytes(data: Bytes): Result<JSONValue, boolean> // This is new
}
```

To make this possible, a generic `Result<V, E>` type is introduced.