### PR TITLE
Remove arweave and box namespaces

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -101,15 +101,6 @@ export declare namespace ens {
   function nameByHash(hash: string): string | null
 }
 
-export declare namespace arweave {
-  /** Returns `null` if the transaction is not found. */
-  function transactionData(txId: string): Bytes | null
-}
-export declare namespace box {
-  /** Returns `null` if the profile is not found. */
-  function profile(address: string): TypedMap<string, JSONValue> | null
-}
-
 function format(fmt: string, args: string[]): string {
   let out = ''
   let argIndex = 0


### PR DESCRIPTION
This should be included for the next release, corresponding to apiVersion 0.0.5. See https://github.com/graphprotocol/graph-node/pull/2645.