### PR TITLE
Add baseFee to Block class

### DIFF
--- a/chain/ethereum.ts
+++ b/chain/ethereum.ts
@@ -355,6 +355,7 @@ export namespace ethereum {
     number: BigInt
     gasUsed: BigInt
     gasLimit: BigInt
+    baseFeePerGas: BigInt | null
     timestamp: BigInt
     difficulty: BigInt
     totalDifficulty: BigInt


### PR DESCRIPTION
Adds an optional baseFee to the Block class, following [EIP-3044](https://eips.ethereum.org/EIPS/eip-3044).

A separate PR will populate this value in the graphprotocol/graph-node repo.