### PR TITLE
Use alpha tag on npm publish alpha minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "test": "node test/test.js",
     "release:patch": "npm version patch && npm publish && git push origin master && git push --tags",
     "release:minor": "npm version minor && npm publish && git push origin master && git push --tags",
-    "release:alpha:minor": "npm version preminor --preid alpha && npm publish && git push origin master && git push --tags"
+    "release:alpha:minor": "npm version preminor --preid alpha && npm publish --tag alpha && git push origin master && git push --tags"
   }
 }


### PR DESCRIPTION
Just a simple fix so when someone tries to publish an alpha version, it doesn't get tagged as `latest` (gets tagged as `alpha` instead).

This is important so when an alpha is released, it isn't the default when people try to install it.