### PR TITLE
common: Add 'zero'/'empty' static methods

### DIFF
--- a/common/collections.ts
+++ b/common/collections.ts
@@ -18,6 +18,10 @@ export class ByteArray extends Uint8Array {
     return self
   }
 
+  static empty(): ByteArray {
+    return ByteArray.fromI32(0)
+  }
+
   /**
    * Input length must be even.
    */
@@ -145,6 +149,10 @@ export class Bytes extends ByteArray {
 
   static fromUint8Array(uint8Array: Uint8Array): Bytes {
     return changetype<Bytes>(uint8Array)
+  }
+
+  static empty(): Bytes {
+    return changetype<Bytes>(ByteArray.empty())
   }
 }
 

--- a/common/numbers.ts
+++ b/common/numbers.ts
@@ -34,6 +34,16 @@ export class Address extends Bytes {
   static fromString(s: string): Address {
     return changetype<Address>(typeConversion.stringToH160(s))
   }
+
+  static zero(): Address {
+    let self = new ByteArray(20)
+
+    for (let i = 0; i < 20; i++) {
+      self[i] = 0
+    }
+
+    return changetype<Address>(self)
+  }
 }
 
 /** An arbitrary size integer represented as an array of bytes. */
@@ -41,6 +51,10 @@ export class BigInt extends Uint8Array {
   static fromI32(x: i32): BigInt {
     let byteArray = ByteArray.fromI32(x)
     return BigInt.fromByteArray(byteArray)
+  }
+
+  static zero(): BigInt {
+    return BigInt.fromI32(0)
   }
 
   /**
@@ -278,6 +292,10 @@ export class BigDecimal {
 
   static fromString(s: string): BigDecimal {
     return bigDecimal.fromString(s)
+  }
+
+  static zero(): BigDecimal {
+    return new BigDecimal(BigInt.zero())
   }
 
   toString(): string {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphprotocol/graph-ts",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
-  "version": "0.22.0-alpha.1",
+  "version": "0.22.0-alpha.2",
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",


### PR DESCRIPTION
These methods are being added for:

- Being helpful/useful to subgraph developers
- Ease some zero/empty value initialization in graph-cli