### PR TITLE
numbers: Add proper safety to operator overloading

### DIFF
--- a/common/numbers.ts
+++ b/common/numbers.ts
@@ -137,21 +137,25 @@ export class BigInt extends Uint8Array {
 
   @operator('+')
   plus(other: BigInt): BigInt {
+    assert(this !== null, "Failed to sum BigInts because left hand side is 'null'");
     return bigInt.plus(this, other)
   }
 
   @operator('-')
   minus(other: BigInt): BigInt {
+    assert(this !== null, "Failed to subtract BigInts because left hand side is 'null'");
     return bigInt.minus(this, other)
   }
 
   @operator('*')
   times(other: BigInt): BigInt {
+    assert(this !== null, "Failed to multiply BigInts because left hand side is 'null'");
     return bigInt.times(this, other)
   }
 
   @operator('/')
   div(other: BigInt): BigInt {
+    assert(this !== null, "Failed to divide BigInts because left hand side is 'null'");
     return bigInt.dividedBy(this, other)
   }
 
@@ -161,6 +165,7 @@ export class BigInt extends Uint8Array {
 
   @operator('%')
   mod(other: BigInt): BigInt {
+    assert(this !== null, "Failed to apply module to BigInt because left hand side is 'null'");
     return bigInt.mod(this, other)
   }
 
@@ -319,21 +324,25 @@ export class BigDecimal {
 
   @operator('+')
   plus(other: BigDecimal): BigDecimal {
+    assert(this !== null, "Failed to sum BigDecimals because left hand side is 'null'");
     return bigDecimal.plus(this, other)
   }
 
   @operator('-')
   minus(other: BigDecimal): BigDecimal {
+    assert(this !== null, "Failed to subtract BigDecimals because left hand side is 'null'");
     return bigDecimal.minus(this, other)
   }
 
   @operator('*')
   times(other: BigDecimal): BigDecimal {
+    assert(this !== null, "Failed to multiply BigDecimals because left hand side is 'null'");
     return bigDecimal.times(this, other)
   }
 
   @operator('/')
   div(other: BigDecimal): BigDecimal {
+    assert(this !== null, "Failed to divide BigDecimals because left hand side is 'null'");
     return bigDecimal.dividedBy(this, other)
   }
 
@@ -369,6 +378,7 @@ export class BigDecimal {
 
   @operator.prefix('-')
   neg(): BigDecimal {
+    assert(this !== null, "Failed to negate BigDecimal because the value of it is 'null'");
     return new BigDecimal(new BigInt(0)) - this
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphprotocol/graph-ts",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
-  "version": "0.22.0-alpha.2",
+  "version": "0.22.0-alpha.3",
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",


### PR DESCRIPTION
AssemblyScript (`0.19.10`) has a bug that allows operator overloading functions to be called with nullable values only when they are class properties, like this:

```ts
class BigInt extends Uint8Array {
    @operator('+')
    plus(other: BigInt): BigInt {
        // ...
    }
}

class Wrapper {
    public constructor(
        public n: BigInt | null
    ) {}
}

let x = BigInt.fromI32(2);
let y: BigInt | null = null;

// x + y; // give compile time error about nullability

let wrapper = new Wrapper(y);

wrapper.n = wrapper.n + x; // doesn't give compile time errors as it should
```

To fix this, we must change the type signature of the operator overloading methods, like this:
```ts
@operator('+')
plus(other: BigInt | null): BigInt {
  // Do null checks
}
```

I would like to write a test for each of these operator overloading changes, however it would be very difficult to test, since I would have to mock the host-exports function for each of them (implemented in the Rust/graph-node side).

Related PR in `graph-node`: https://github.com/graphprotocol/graph-node/pull/2780