### PR TITLE
chain: Fix upcast runtime error in toTupleArray

### DIFF
--- a/chain/ethereum.ts
+++ b/chain/ethereum.ts
@@ -113,7 +113,7 @@ export namespace ethereum {
       let valueArray = this.toArray()
       let out = new Array<T>(valueArray.length)
       for (let i: i32 = 0; i < valueArray.length; i++) {
-        out[i] = <T>valueArray[i].toTuple()
+        out[i] = changetype<T>(valueArray[i].toTuple())
       }
       return out
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphprotocol/graph-ts",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",


### PR DESCRIPTION
This change is needed because this cast is NOT safe, so `changetype` is necessary.

Just like it's explained [here on the migration guide](https://thegraph.com/docs/developer/assemblyscript-migration-guide#casting).

I've looked into the [changes between releases](https://github.com/graphprotocol/graph-ts/compare/v0.20.1...v0.22.0), and this seems to be the only wrong upcast needed to fix.

Fixes: https://github.com/graphprotocol/graph-node/issues/2799