### PR TITLE
Release 0.23.0-alpha.1 - NEAR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphprotocol/graph-ts",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
-  "version": "0.23.0-alpha.0",
+  "version": "0.23.0-alpha.1",
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",


### PR DESCRIPTION
Because in the past I've made the mistake to publish the version `0.23.0-alpha.0` of `graph-ts` on npm, I'm doing `0.23.0-alpha.1`.

The wrong one has been deprecated for 2 months already: https://www.npmjs.com/package/@graphprotocol/graph-ts/v/0.23.0-alpha.0