### PR TITLE
0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphprotocol/graph-ts",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
-  "version": "0.24.0-alpha.1",
+  "version": "0.24.0",
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",


### PR DESCRIPTION
- New fields for `apiVersion: 0.0.6` https://github.com/graphprotocol/graph-ts/pull/213
  - `Transaction.nonce`
  - `Block.baseFeePerGas`
- Fix export of `fromString` functions in `json` namespace https://github.com/graphprotocol/graph-ts/pull/231