### PR TITLE
v0.24.1

### DIFF
--- a/chain/ethereum.ts
+++ b/chain/ethereum.ts
@@ -356,7 +356,7 @@ export namespace ethereum {
       public gasLimit: BigInt,
       public gasPrice: BigInt,
       public input: Bytes,
-      public nonce: Bytes,
+      public nonce: BigInt,
     ) {}
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphprotocol/graph-ts",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",


### PR DESCRIPTION
Changes the `Transaction.nonce` field type from `Bytes` to `BigInt`.