### PR TITLE
Improved the typings of the `assert` function

### DIFF
--- a/types/override/index.d.ts
+++ b/types/override/index.d.ts
@@ -1,0 +1,7 @@
+// Re-declares the `assert` function defined by AssemblyScript directly. By using this
+// definition, someone is now able to do something like this:
+//
+//     assert(value != null, "Value must never be null at that point")
+//     value.something() // Cool, `value` is know to be `non-null` by the type checker
+//
+declare function assert<T>(isTrueish: T, message?: string): asserts isTrueish

--- a/types/tsconfig.base.json
+++ b/types/tsconfig.base.json
@@ -1,3 +1,7 @@
 {
-  "extends": "assemblyscript/std/assembly"
+  "extends": "assemblyscript/std/assembly",
+  "compilerOptions": {
+    "typeRoots": ["../node_modules/assemblyscript/std/types", "."],
+    "types": ["assembly", "override"]
+  }
 }


### PR DESCRIPTION
TypeScript has a nice way to inform the type checker that a function asserts a certain condition and that after the assertion, the rest of the scope must assume the condition is true.

What this entails is that it's now possible to have much more interesting code when it's time to deal with `null` value.

```
assert(out != null, `JSON key ${key} is not found in JSON Object.`)
out.toObject().get("other")
```

Here, `out` after the `assert` is known to the type checker to be `non-null` because the condition `out != null` now holds for the whole scope after the `assert`.

The same code before the modification in this PR:

```
if (out == null) {
  throw `JSON key ${key} is not found in JSON Object.`
}
out.toObject().get("other")
```

So we gain clarity.

See https://github.com/AssemblyScript/assemblyscript/issues/2195

#### Breaking Change

It's not technically a breaking change because only the type system is involved.