### PR TITLE
Added `mustGet` an `mustGetEntry` to TypedMaped

### DIFF
--- a/common/collections.ts
+++ b/common/collections.ts
@@ -320,7 +320,7 @@ export class TypedMap<K, V> {
 
   mustGetEntry(key: K): TypedMapEntry<K, V> {
     const entry = this.getEntry(key)
-    assert(entry != null, `Entry for key ${key} doest not exist in TypedMap`)
+    assert(entry != null, `Entry for key ${key} does not exist in TypedMap`)
     return entry!
   }
 
@@ -335,7 +335,7 @@ export class TypedMap<K, V> {
 
   mustGet(key: K): V {
     const value = this.get(key)
-    assert(value != null, `Value for key ${key} doest not exist in TypedMap`)
+    assert(value != null, `Value for key ${key} does not exist in TypedMap`)
     return value!
   }
 

--- a/common/collections.ts
+++ b/common/collections.ts
@@ -318,6 +318,12 @@ export class TypedMap<K, V> {
     return null
   }
 
+  mustGetEntry(key: K): TypedMapEntry<K, V> {
+    const entry = this.getEntry(key)
+    assert(entry != null, `Entry for key ${key} doest not exist in TypedMap`)
+    return entry!
+  }
+
   get(key: K): V | null {
     for (let i: i32 = 0; i < this.entries.length; i++) {
       if (this.entries[i].key == key) {
@@ -325,6 +331,12 @@ export class TypedMap<K, V> {
       }
     }
     return null
+  }
+
+  mustGet(key: K): V {
+    const value = this.get(key)
+    assert(value != null, `Value for key ${key} doest not exist in TypedMap`)
+    return value!
   }
 
   isSet(key: K): bool {


### PR DESCRIPTION
This adds two small helpers that make it easier to work with `JSONValue` so that it's possible to get elements from objects more tersely.

#### Open Questions

I noticed that `Entity` which extends `TypeMap` uses `get` without checking `null` and only using typing tricks to remove the nullability that `get` brings.

So I'm wondering:
- Should I remove the `assert` in the `must...` version
- Or should we change `Entity` to now use `mustGet` instead