### PR TITLE
Introduce `TransactionReceipt` and `Log`

### DIFF
--- a/chain/ethereum.ts
+++ b/chain/ethereum.ts
@@ -361,6 +361,44 @@ export namespace ethereum {
   }
 
   /**
+   * An Ethereum transaction receipt.
+   */
+  export class TransactionReceipt {
+    constructor(
+      public transactionHash: Bytes,
+      public transactionIndex: BigInt,
+      public blockHash: Bytes,
+      public blockNumber: BigInt,
+      public cumulativeGasUsed: BigInt,
+      public gasUsed: BigInt,
+      public contractAddress: Address,
+      public logs: Array<Log>,
+      public status: BigInt,
+      public root: Bytes,
+      public logsBloom: Bytes,
+    ) {}
+  }
+
+  /**
+   * An Ethereum event log.
+   */
+  export class Log {
+    constructor(
+      public address: Address,
+      public topics: Array<Bytes>,
+      public data: Bytes,
+      public blockHash: Bytes,
+      public blockNumber: Bytes,
+      public transactionHash: Bytes,
+      public transactionIndex: BigInt,
+      public logIndex: BigInt,
+      public transactionLogIndex: BigInt,
+      public logType: string,
+      public removed: boolean,
+    ) {}
+  }
+
+  /**
    * Common representation for Ethereum smart contract calls.
    */
   export class Call {
@@ -386,6 +424,7 @@ export namespace ethereum {
       public block: Block,
       public transaction: Transaction,
       public parameters: Array<EventParam>,
+      public receipt: TransactionReceipt | null,
     ) {}
   }
 

--- a/chain/ethereum.ts
+++ b/chain/ethereum.ts
@@ -394,7 +394,7 @@ export namespace ethereum {
       public logIndex: BigInt,
       public transactionLogIndex: BigInt,
       public logType: string,
-      public removed: boolean,
+      public removed: Wrapped<bool> | null,
     ) {}
   }
 

--- a/global/global.ts
+++ b/global/global.ts
@@ -65,6 +65,7 @@ export enum TypeId {
   ArrayF32 = 49,
   ArrayF64 = 50,
   ArrayBigDecimal = 51,
+  // Near types
   NearArrayDataReceiver = 52,
   NearArrayCryptoHash = 53,
   NearArrayActionValue = 54,
@@ -100,6 +101,7 @@ export enum TypeId {
   NearChunkHeader = 84,
   NearBlock = 85,
   NearReceiptWithOutcome = 86,
+  // Tendermint types
   TendermintArrayEventTx = 87,
   TendermintArrayEvent = 88,
   TendermintArrayCommitSig = 89,
@@ -147,6 +149,11 @@ export enum TypeId {
   TendermintDuration = 131,
   TendermintTimestamp = 132,
   TendermintEventData = 133,
+  // More ethereum types
+  TransactionReceipt = 134,
+  Log = 135,
+  ArrayH256 = 136,
+  ArrayLog = 137,
 }
 
 export function id_of_type(typeId: TypeId): usize {
@@ -420,6 +427,14 @@ export function id_of_type(typeId: TypeId): usize {
       return idof<tendermint.Timestamp>()
     case TypeId.TendermintEventData:
       return idof<tendermint.EventData>()
+    case TypeId.TransactionReceipt:
+      return idof<ethereum.TransactionReceipt>()
+    case TypeId.Log:
+      return idof<ethereum.Log>()
+    case TypeId.ArrayH256:
+      return idof<Array<Uint8Array>>()
+    case TypeId.ArrayLog:
+      return idof<Array<ethereum.Log>>()
     default:
       return 0
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphprotocol/graph-ts",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
-  "version": "0.26.0",
+  "version": "0.27.0-alpha.0",
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",


### PR DESCRIPTION
This PR introduces two new Ethereum types:
- `TransactionReceipt`
- `Log`

Since `apiVersion 0.0.7`, subgraphs can request transaction receipts inside event handlers, so, for now, `TransactionReceipt` is stored in `Event.receipt` _(which is a nullable field)_.

This also bumps the `npm` version to `0.27.0`

---
This PR is a dependency of:
- https://github.com/graphprotocol/graph-node/pull/3373
- https://github.com/graphprotocol/graph-cli/pull/860