### PR TITLE
add ascMain

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "index.ts",
   "types": "index.ts",
   "main": "index.ts",
+  "ascMain": "index.ts",
   "dependencies": {
     "assemblyscript": "0.19.10"
   },


### PR DESCRIPTION
So that it aligns with the assemblyscript convention that if index.ts is not under assembly/, then specify ascMain.

This way, I can import graph-ts into as-pect, which is a unit test framework for assemblyscript. See https://github.com/as-pect/as-pect/issues/388 for details